### PR TITLE
I've fixed the navigation link highlighting on click and scroll.

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@
         <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
             <h1 class="text-xl font-bold">Charles de Pirey</h1>
             <div class="flex items-center space-x-4">
-                <div class="hidden md:flex space-x-8">
+                <div class="hidden md:flex space-x-8 nav-list">
                     <a href="#overview" class="nav-link active" data-lang-key="nav_overview">Vue d'ensemble</a>
                     <a href="#experience" class="nav-link" data-lang-key="nav_career">Parcours</a>
                     <a href="#skills" class="nav-link" data-lang-key="nav_skills">Compétences</a>
@@ -1219,8 +1219,20 @@
             document.querySelectorAll('.nav-link, .nav-link-mobile').forEach(link => {
                 link.addEventListener('click', function(e) {
                     e.preventDefault(); // Prevent default jump
-                    const targetId = this.getAttribute('href').substring(1);
-                    const targetSection = document.getElementById(targetId);
+                    const targetId = this.getAttribute('href');
+
+                    // Remove active class from all desktop nav links
+                    document.querySelectorAll('.nav-link').forEach(navLink => {
+                        navLink.classList.remove('active');
+                    });
+
+                    // Add active class to the clicked link
+                    const activeLink = document.querySelector(`.nav-link[href="${targetId}"]`);
+                    if (activeLink) {
+                        activeLink.classList.add('active');
+                    }
+
+                    const targetSection = document.getElementById(targetId.substring(1));
                     if (targetSection) {
                         // Scroll to the target section, offset by the nav bar height
                         const navHeight = document.querySelector('header').offsetHeight; // Get header height


### PR DESCRIPTION
I found that the navigation link highlighting was not working as you expected. This was due to two issues:
1. The `IntersectionObserver` responsible for highlighting on scroll was using an incorrect selector (`.nav-list`), which did not exist in the HTML.
2. The click handler for navigation links did not update the `active` class, so the highlighting did not change immediately on click.

To fix this, I:
- Added the `nav-list` class to the navigation `div` element, allowing the `IntersectionObserver` to function correctly.
- Updated the JavaScript click event listener to immediately add the `active` class to the clicked navigation link and remove it from the others. This provides instant visual feedback to you.